### PR TITLE
Change proto dependency to google-cloud-datastore

### DIFF
--- a/python/googledatastore/__init__.py
+++ b/python/googledatastore/__init__.py
@@ -23,7 +23,7 @@ from . import connection
 from .connection import *
 # Import the Datastore protos. These are listed separately to avoid importing
 # the Datastore service, which conflicts with our Datastore class.
-from google.cloud.proto.datastore.v1.datastore_pb2 import (
+from google.cloud.datastore_v1.proto.datastore_pb2 import (
     LookupRequest,
     LookupResponse,
     RunQueryRequest,
@@ -39,8 +39,8 @@ from google.cloud.proto.datastore.v1.datastore_pb2 import (
     Mutation,
     MutationResult,
     ReadOptions)
-from google.cloud.proto.datastore.v1.entity_pb2 import *
-from google.cloud.proto.datastore.v1.query_pb2 import *
+from google.cloud.datastore_v1.proto.entity_pb2 import *
+from google.cloud.datastore_v1.proto.query_pb2 import *
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from google.protobuf.struct_pb2 import NULL_VALUE

--- a/python/googledatastore/connection.py
+++ b/python/googledatastore/connection.py
@@ -19,7 +19,7 @@ import logging
 import httplib2
 
 from googledatastore import helper
-from google.cloud.proto.datastore.v1 import datastore_pb2
+from google.cloud.datastore_v1.proto import datastore_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import code_pb2
 from google.rpc import status_pb2

--- a/python/googledatastore/helper.py
+++ b/python/googledatastore/helper.py
@@ -22,8 +22,8 @@ import os
 
 import httplib2
 from oauth2client import client
-from google.cloud.proto.datastore.v1 import entity_pb2
-from google.cloud.proto.datastore.v1 import query_pb2
+from google.cloud.datastore_v1.proto import entity_pb2
+from google.cloud.datastore_v1.proto import query_pb2
 
 __all__ = [
     'get_credentials_from_env',

--- a/python/setup.py
+++ b/python/setup.py
@@ -27,7 +27,7 @@ REQUIREMENTS = [
 ]
 
 if sys.version < (3, 1):
-    # Avoids installing dependency versions that dropped Python 2 support.
+    # Constrain sub-dependencies to versions that support Python 2.
     REQUIREMENTS.extend([
         'cachetools<4',
         'rsa<4',

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,9 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import sys
+
 from setuptools import setup
 
 __version__ = '7.0.3'
+
+REQUIREMENTS = [
+    'google-cloud-datastore==1.15.3',
+    'httplib2>=0.9.1,<=0.12.0',
+    'oauth2client>=2.0.1,<4.0.0',
+]
+
+if sys.version < (3, 1):
+    # Avoids installing dependency versions that dropped Python 2 support.
+    REQUIREMENTS.extend([
+        'cachetools<4',
+        'rsa<4',
+    ])
 
 setup(
     name='googledatastore',
@@ -27,13 +43,7 @@ setup(
     url='https://github.com/GoogleCloudPlatform/google-cloud-datastore',
     packages=['googledatastore'],
     package_dir={'googledatastore': 'googledatastore'},
-    install_requires=[
-        'cachetools<4',
-        'google-cloud-datastore==1.15.3',
-        'httplib2>=0.9.1,<=0.12.0',
-        'oauth2client>=2.0.1,<4.0.0',
-        'rsa<4',
-    ],
+    install_requires=REQUIREMENTS,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Topic :: Database',

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,25 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-import sys
-
 from setuptools import setup
 
 __version__ = '7.0.3'
-
-REQUIREMENTS = [
-    'google-cloud-datastore==1.15.3',
-    'httplib2>=0.9.1,<=0.12.0',
-    'oauth2client>=2.0.1,<4.0.0',
-]
-
-if sys.version < (3,):
-    # Constrain sub-dependencies to versions that support Python 2.
-    REQUIREMENTS.extend([
-        'cachetools<4',
-        'rsa<4',
-    ])
 
 setup(
     name='googledatastore',
@@ -43,7 +27,13 @@ setup(
     url='https://github.com/GoogleCloudPlatform/google-cloud-datastore',
     packages=['googledatastore'],
     package_dir={'googledatastore': 'googledatastore'},
-    install_requires=REQUIREMENTS,
+    install_requires=[
+        'cachetools<4',
+        'google-cloud-datastore==1.15.3',
+        'httplib2>=0.9.1,<=0.12.0',
+        'oauth2client>=2.0.1,<4.0.0',
+        'rsa<4',
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Topic :: Database',

--- a/python/setup.py
+++ b/python/setup.py
@@ -26,7 +26,7 @@ REQUIREMENTS = [
     'oauth2client>=2.0.1,<4.0.0',
 ]
 
-if sys.version < (3, 1):
+if sys.version < (3,):
     # Constrain sub-dependencies to versions that support Python 2.
     REQUIREMENTS.extend([
         'cachetools<4',

--- a/python/setup.py
+++ b/python/setup.py
@@ -15,7 +15,7 @@
 #
 from setuptools import setup
 
-__version__ = '7.0.2'
+__version__ = '7.0.3'
 
 setup(
     name='googledatastore',
@@ -28,9 +28,11 @@ setup(
     packages=['googledatastore'],
     package_dir={'googledatastore': 'googledatastore'},
     install_requires=[
+        'cachetools<4',
+        'google-cloud-datastore==1.15.3',
         'httplib2>=0.9.1,<=0.12.0',
         'oauth2client>=2.0.1,<4.0.0',
-        'proto-google-cloud-datastore-v1>=0.90.0',
+        'rsa<4',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Tested by running both the demos (demos/todos/todos.py, demos/trivial/adams.py)
using my personal Google Cloud project.

Both of them were able to communicate with the server and create models.
